### PR TITLE
intel_edison_fab_c.c: Enable pinmux for CTS/RTS pins

### DIFF
--- a/src/x86/intel_edison_fab_c.c
+++ b/src/x86/intel_edison_fab_c.c
@@ -646,9 +646,25 @@ mraa_intel_edison_uart_init_pre(int index)
         mraa_gpio_close(io1_output);
         mraa_gpio_close(io1_pullup);
     }
+
+    /**
+     * Change pinmode for uart pins
+     */
     mraa_result_t ret;
-    ret = mraa_intel_edison_pinmode_change(130, 1); // IO0 RX
-    ret = mraa_intel_edison_pinmode_change(131, 1); // IO1 TX
+    int i = 128;
+    for (; i < 132; i++) {
+        /**
+         * 128 == CTS
+         * 129 == RTS
+         * 130 == RX
+         * 131 = Tx
+         *
+         */
+        ret = mraa_intel_edison_pinmode_change(i, 1); // IO0 RX
+        if (ret != MRAA_SUCCESS) {
+            return ret;
+        }
+    }
     return ret;
 }
 


### PR DESCRIPTION
This enables the RTS & CTS pins on the uart in the init pre section. They then
won't be available as normal GPIOs.

Signed-off-by: Brendan Le Foll <brendan.le.foll@intel.com>