### PR TITLE
mraa.c: fix memleak in find_i2c_bus_pci

### DIFF
--- a/src/mraa.c
+++ b/src/mraa.c
@@ -957,9 +957,15 @@ mraa_find_i2c_bus_pci(const char* pci_device, const char *pci_id, const char* ad
                         if (token != NULL) {
                             int ret = -1;
                             if (mraa_atoi(token, &ret) == MRAA_SUCCESS) {
+                                free(dup);
+                                free(namelist[n]);
+                                free(namelist);
                                 syslog(LOG_NOTICE, "Adding i2c bus found on i2c-%d on adapter %s", ret, adapter_name);
                                 return ret;
                             }
+                            free(dup);
+                            free(namelist[n]);
+                            free(namelist);
                             return -1;
                         }
                     }


### PR DESCRIPTION
Signed-off-by: Brendan Le Foll <brendan.le.foll@intel.com>