### PR TITLE
api: make all simple io calls returning unsinged ints returned signed…

### DIFF
--- a/api/mraa/aio.h
+++ b/api/mraa/aio.h
@@ -60,12 +60,12 @@ mraa_aio_context mraa_aio_init(unsigned int pin);
 
 /**
  * Read the input voltage. By default mraa will shift
- * the raw value up or down to a 10 bit value.
+ * the raw value up or down to a 10 bit value. Returns -1 if error
  *
  * @param dev The AIO context
  * @returns The current input voltage.
  */
-unsigned int mraa_aio_read(mraa_aio_context dev);
+int mraa_aio_read(mraa_aio_context dev);
 
 /**
  * Read the input voltage and return it as a normalized float (0.0f-1.0f).

--- a/api/mraa/aio.hpp
+++ b/api/mraa/aio.hpp
@@ -1,6 +1,6 @@
 /*
  * Author: Brendan Le Foll <brendan.le.foll@intel.com>
- * Copyright (c) 2014 Intel Corporation.
+ * Copyright (c) 2014-2016 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -62,25 +62,35 @@ class Aio
         mraa_aio_close(m_aio);
     }
     /**
-     * Read a value from the AIO pin. By default mraa will shift
-     * the raw value up or down to a 10 bit value.
+     * Read a value from the AIO pin. By default mraa will shift the raw value
+     * up or down to a 10 bit value. -1 indicates an error
      *
+     * @throws std::logic_error if read fails
      * @returns The current input voltage. By default, a 10bit value
      */
     int
     read()
     {
-        return mraa_aio_read(m_aio);
+        int val = mraa_aio_read(m_aio);
+	if (val == -1) {
+            throw std::runtime_error("Unkown error whilst reading from ADC");
+        }
+        return val;
     }
     /**
      * Read a value from the AIO pin and return it as a normalized float.
      *
+     * @throws std::logic_error if read fails
      * @returns The current input voltage as a normalized float (0.0f-1.0f)
      */
     float
     readFloat()
     {
-        return mraa_aio_read_float(m_aio);
+        float val = mraa_aio_read_float(m_aio);
+        if (val == -1.0) {
+            throw std::runtime_error("Unkown error whilst reading from ADC");
+        }
+        return val;
     }
     /**
      * Set the bit value which mraa will shift the raw reading

--- a/api/mraa/i2c.h
+++ b/api/mraa/i2c.h
@@ -1,6 +1,6 @@
 /*
  * Author: Brendan Le Foll <brendan.le.foll@intel.com>
- * Copyright (c) 2014 Intel Corporation.
+ * Copyright (c) 2014-2016 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -93,27 +93,27 @@ int mraa_i2c_read(mraa_i2c_context dev, uint8_t* data, int length);
  * with the i2c offset 0x0
  *
  * @param dev The i2c context
- * @return The result of the read and 0 if failed
+ * @return The result of the read and -1 if failed
  */
-uint8_t mraa_i2c_read_byte(mraa_i2c_context dev);
+int mraa_i2c_read_byte(mraa_i2c_context dev);
 
 /**
  * Read a single byte from i2c context, from designated register
  *
  * @param dev The i2c context
  * @param command The register
- * @return The result of the read and 0 if failed
+ * @return The result of the read and -1 if failed
  */
-uint8_t mraa_i2c_read_byte_data(mraa_i2c_context dev, const uint8_t command);
+int mraa_i2c_read_byte_data(mraa_i2c_context dev, const uint8_t command);
 
 /**
  * Read a single word from i2c context, from designated register
  *
  * @param dev The i2c context
  * @param command The register
- * @return The result of the read and 0 if failed
+ * @return The result of the read and -1 if failed
  */
-uint16_t mraa_i2c_read_word_data(mraa_i2c_context dev, const uint8_t command);
+int mraa_i2c_read_word_data(mraa_i2c_context dev, const uint8_t command);
 
 /**
  * Bulk read from i2c context, starting from designated register

--- a/api/mraa/spi.h
+++ b/api/mraa/spi.h
@@ -1,6 +1,7 @@
 /*
  * Author: Thomas Ingleby <thomas.c.ingleby@intel.com>
- * Copyright (c) 2014 Intel Corporation.
+ * Author: Brendan Le Foll <brendan.le.foll@intel.com>
+ * Copyright (c) 2014-2016 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -111,13 +112,13 @@ mraa_result_t mraa_spi_frequency(mraa_spi_context dev, int hz);
 int mraa_spi_write(mraa_spi_context dev, uint8_t data);
 
 /**
- *Write Two Bytes to the SPI device.
+ * Write Two Bytes to the SPI device.
  *
  * @param dev The Spi context
  * @param data Data to send
- * @return Data received on the miso line
+ * @return Data received on the miso line or -1 if error
  */
-uint16_t mraa_spi_write_word(mraa_spi_context dev, uint16_t data);
+int mraa_spi_write_word(mraa_spi_context dev, uint16_t data);
 
 /**
  * Write Buffer of bytes to the SPI device. The pointer return has to be

--- a/src/aio/aio.c
+++ b/src/aio/aio.c
@@ -152,7 +152,7 @@ mraa_aio_init(unsigned int aio)
     return dev;
 }
 
-unsigned int
+int
 mraa_aio_read(mraa_aio_context dev)
 {
     if (IS_FUNC_DEFINED(dev, aio_read_replace)) {
@@ -165,7 +165,7 @@ mraa_aio_read(mraa_aio_context dev)
     if (dev->adc_in_fp == -1) {
         if (aio_get_valid_fp(dev) != MRAA_SUCCESS) {
             syslog(LOG_ERR, "aio: Failed to get to the device");
-            return 0;
+            return -1;
         }
     }
 
@@ -197,7 +197,7 @@ mraa_aio_read(mraa_aio_context dev)
         }
     }
 
-    return analog_value;
+    return (int) analog_value;
 }
 
 float
@@ -205,7 +205,7 @@ mraa_aio_read_float(mraa_aio_context dev)
 {
     if (dev == NULL) {
         syslog(LOG_ERR, "aio: Device not valid");
-        return 0.0;
+        return -1.0;
     }
 
     float max_analog_value = (1 << dev->value_bit) - 1;

--- a/src/i2c/i2c.c
+++ b/src/i2c/i2c.c
@@ -1,6 +1,6 @@
 /*
  * Author: Brendan Le Foll <brendan.le.foll@intel.com>
- * Copyright (c) 2014 Intel Corporation.
+ * Copyright (c) 2014-2016 Intel Corporation.
  *
  * Code is modified from the RoadNarrows-robotics i2c library (distributed under
  * the MIT license, license is included verbatim under src/i2c/LICENSE)
@@ -216,41 +216,41 @@ mraa_i2c_read(mraa_i2c_context dev, uint8_t* data, int length)
     return 0;
 }
 
-uint8_t
+int
 mraa_i2c_read_byte(mraa_i2c_context dev)
 {
     if (IS_FUNC_DEFINED(dev, i2c_read_byte_replace))
         return dev->advance_func->i2c_read_byte_replace(dev);
     i2c_smbus_data_t d;
     if (mraa_i2c_smbus_access(dev->fh, I2C_SMBUS_READ, I2C_NOCMD, I2C_SMBUS_BYTE, &d) < 0) {
-        syslog(LOG_ERR, "i2c: Failed to write");
-        return 0;
+        syslog(LOG_ERR, "i2c: Failed to write to bus from mraa_i2c_read_byte");
+        return -1;
     }
     return 0x0FF & d.byte;
 }
 
-uint8_t
+int
 mraa_i2c_read_byte_data(mraa_i2c_context dev, uint8_t command)
 {
     if (IS_FUNC_DEFINED(dev, i2c_read_byte_data_replace))
         return dev->advance_func->i2c_read_byte_data_replace(dev, command);
     i2c_smbus_data_t d;
     if (mraa_i2c_smbus_access(dev->fh, I2C_SMBUS_READ, command, I2C_SMBUS_BYTE_DATA, &d) < 0) {
-        syslog(LOG_ERR, "i2c: Failed to write");
-        return 0;
+        syslog(LOG_ERR, "i2c: Failed to write to bus from mraa_i2c_read_byte_data");
+        return -1;
     }
     return 0x0FF & d.byte;
 }
 
-uint16_t
+int
 mraa_i2c_read_word_data(mraa_i2c_context dev, uint8_t command)
 {
     if (IS_FUNC_DEFINED(dev, i2c_read_word_data_replace))
         return dev->advance_func->i2c_read_word_data_replace(dev, command);
     i2c_smbus_data_t d;
     if (mraa_i2c_smbus_access(dev->fh, I2C_SMBUS_READ, command, I2C_SMBUS_WORD_DATA, &d) < 0) {
-        syslog(LOG_ERR, "i2c: Failed to write");
-        return 0;
+        syslog(LOG_ERR, "i2c: Failed to write to bus from mraa_i2c_read_word_data");
+        return -1;
     }
     return 0xFFFF & d.word;
 }

--- a/src/spi/spi.c
+++ b/src/spi/spi.c
@@ -1,7 +1,7 @@
 /*
  * Author: Thomas Ingleby <thomas.c.ingleby@intel.com>
  * Author: Brendan Le Foll <brendan.le.foll@intel.com>
- * Copyright (c) 2014, 2015 Intel Corporation.
+ * Copyright (c) 2014 - 2016 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -265,7 +265,7 @@ mraa_spi_write(mraa_spi_context dev, uint8_t data)
     return (int) recv;
 }
 
-uint16_t
+int
 mraa_spi_write_word(mraa_spi_context dev, uint16_t data)
 {
     struct spi_ioc_transfer msg;
@@ -284,7 +284,7 @@ mraa_spi_write_word(mraa_spi_context dev, uint16_t data)
         syslog(LOG_ERR, "spi: Failed to perform dev transfer");
         return -1;
     }
-    return recv;
+    return (int) recv;
 }
 
 mraa_result_t


### PR DESCRIPTION
… int and -1 in errors

This commit changes the 0.x mraa API (0.3.x really) to use -1 as returns in
cases of errors and adds throws in the C++ variants. This is a rather small
change but does technically brake the API. Most users should not see a big
difference since UPM will be updated

Signed-off-by: Brendan Le Foll <brendan.le.foll@intel.com>